### PR TITLE
rangos de color corregidos

### DIFF
--- a/icovid-vacunacion/nuevos_vacunas.py
+++ b/icovid-vacunacion/nuevos_vacunas.py
@@ -107,9 +107,9 @@ aux_join_final["cobertura"] = round(100 * (aux_join_final["segunda_dosis"] + aux
 nacional = aux_join_final[["Fecha", "avance", "cobertura"]]
 copy_nacional = nacional.copy()
 copy_nacional.loc[copy_nacional.cobertura < 50, "rango_cobertura"] = "<50" # rojo
-copy_nacional.loc[(copy_nacional.cobertura < 70) & (copy_nacional.cobertura > 49), "rango_cobertura"] = "50-69" # naranjo
-copy_nacional.loc[(copy_nacional.cobertura < 90) & (copy_nacional.cobertura > 69), "rango_cobertura"] = "70-89" # amarillo
-copy_nacional.loc[copy_nacional.cobertura > 89, "rango_cobertura"] = ">=90" # verde
+copy_nacional.loc[(copy_nacional.cobertura < 70) & (copy_nacional.cobertura >= 50), "rango_cobertura"] = "[50-70[" # naranjo
+copy_nacional.loc[(copy_nacional.cobertura < 90) & (copy_nacional.cobertura >= 70), "rango_cobertura"] = "[70-90[" # amarillo
+copy_nacional.loc[copy_nacional.cobertura >= 90, "rango_cobertura"] = ">=90" # verde
 
 copy_nacional.to_csv(f"{dir_path}/archivos_nuevos_vacunas/total_nacional_vacunas.csv", index=False)
 

--- a/icovid-vacunacion/nuevos_vacunas.py
+++ b/icovid-vacunacion/nuevos_vacunas.py
@@ -74,9 +74,9 @@ reg_sum = reg_final[["region_nombre", "Fecha", "avance_porcentual", "cobertura_p
 ## RANGOS DE PORCENTAJES DE COBERTURA ##
 copy_reg_sum = reg_sum.copy()
 copy_reg_sum.loc[copy_reg_sum.cobertura_porcentual < 50, "rango_cobertura"] = "<50" # rojo
-copy_reg_sum.loc[(copy_reg_sum.cobertura_porcentual < 70) & (copy_reg_sum.cobertura_porcentual > 49), "rango_cobertura"] = "50-69" # naranjo
-copy_reg_sum.loc[(copy_reg_sum.cobertura_porcentual < 90) & (copy_reg_sum.cobertura_porcentual > 69), "rango_cobertura"] = "70-89" # amarillo
-copy_reg_sum.loc[copy_reg_sum.cobertura_porcentual > 89, "rango_cobertura"] = ">=90" # verde
+copy_reg_sum.loc[(copy_reg_sum.cobertura_porcentual < 70) & (copy_reg_sum.cobertura_porcentual >= 50), "rango_cobertura"] = "[50-70[" # naranjo
+copy_reg_sum.loc[(copy_reg_sum.cobertura_porcentual < 90) & (copy_reg_sum.cobertura_porcentual >= 70), "rango_cobertura"] = "[70-90[" # amarillo
+copy_reg_sum.loc[copy_reg_sum.cobertura_porcentual >= 90, "rango_cobertura"] = ">=90" # verde
 
 if os.path.exists(f"{dir_path}/archivos_nuevos_vacunas"):
     shutil.rmtree(f"{dir_path}/archivos_nuevos_vacunas")


### PR DESCRIPTION
Para que incluyan todos los valores de intervalos, y no se pierdan los límites (los valores no enteros entre 69 y 70 por ejemplo)